### PR TITLE
Fix third round of dotfile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CURL := curl -sfL
 GITCONFIG_USER_PATH := ~/.gitconfig_user
 
 # User specific settings
-USER := Sascha Grunert
+GIT_USER := Sascha Grunert
 EMAIL := sgrunert@redhat.com
 SIGNKEY := 79C3DE73D9F8B626A81B990109D97D153EF94D93
 
@@ -30,7 +30,7 @@ switch: ## Build and switch to the NixOS configuration.
 
 gitconfig-user: ## Generate the user-specific gitconfig.
 	rm -f $(GITCONFIG_USER_PATH)
-	$(GIT) config -f $(GITCONFIG_USER_PATH) user.name "$(USER)"
+	$(GIT) config -f $(GITCONFIG_USER_PATH) user.name "$(GIT_USER)"
 	$(GIT) config -f $(GITCONFIG_USER_PATH) user.email "$(EMAIL)"
 	$(GIT) config -f $(GITCONFIG_USER_PATH) user.signkey "$(SIGNKEY)"
 	$(GIT) config -f $(GITCONFIG_USER_PATH) commit.gpgsign true

--- a/i3/config
+++ b/i3/config
@@ -81,7 +81,7 @@ bindsym $mod+Shift+p restart
 bindsym $mod+p reload
 
 # shutdown computer
-bindsym $mod+Shift+s exec "i3-nagbar -t warning -m 'Shutdown the computer?' -b 'Yes' 'sudo shutdown -P now'"
+bindsym $mod+Shift+s exec "i3-nagbar -t warning -m 'Shutdown the computer?' -b 'Yes' 'systemctl poweroff'"
 
 # resize window (you can also use the mouse for that)
 mode "resize" {

--- a/nixos/services.nix
+++ b/nixos/services.nix
@@ -36,7 +36,6 @@
     libinput.enable = true;
 
     udev.extraRules = ''
-      ACTION=="add", SUBSYSTEM=="backlight", KERNEL=="amd_backlight", MODE="0666", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/class/backlight/%k/brightness"
       ACTION=="bind", SUBSYSTEM=="usb", DRIVER=="snd-usb-audio", ATTRS{idVendor}=="10f5", ATTRS{idProduct}=="7001", RUN+="${pkgs.bash}/bin/bash -c 'echo %k > /sys/bus/usb/drivers/snd-usb-audio/unbind 2>/dev/null'"
       ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="10f5", ENV{DEVTYPE}=="usb_device", TAG+="usbip-autoexport", RUN+="${pkgs.bash}/bin/bash -c '${config.boot.kernelPackages.usbip}/bin/usbip bind -b %k 2>/dev/null || true'"
     '';

--- a/nvim/lua/config/autocmds.lua
+++ b/nvim/lua/config/autocmds.lua
@@ -39,17 +39,6 @@ autocmd("FileType", {
   end,
 })
 
--- Return to last edit position
-autocmd("BufReadPost", {
-  group = augroup("LastEditPosition", { clear = true }),
-  callback = function()
-    local line = vim.fn.line("'\"")
-    if line > 0 and line <= vim.fn.line("$") then
-      vim.cmd('normal! g`"')
-    end
-  end,
-})
-
 -- Auto-adjust quickfix height
 autocmd("FileType", {
   group = augroup("QuickfixHeight", { clear = true }),

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -83,9 +83,6 @@ map("n", "p", "p`]", { silent = true })
 -- Select pasted text
 map("n", "gV", "`[v`]")
 
--- Replay last macro
-map("n", "Q", "@@")
-
 -- Upper/lower word
 map("n", "<leader>uu", "mQviwU`Q")
 map("n", "<leader>ud", "mQviwu`Q")

--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -82,14 +82,8 @@ opt.breakindent = true
 -- Path
 opt.path:append("/usr/local/include")
 
--- Fillchars
-opt.fillchars:append({ vert = "│" })
-
 -- Pattern memory
 opt.maxmempattern = 10000
-
--- 24-bit color
-opt.termguicolors = true
 
 -- Sign column
 opt.signcolumn = "yes"

--- a/nvim/lua/plugins/git.lua
+++ b/nvim/lua/plugins/git.lua
@@ -28,7 +28,7 @@ return {
         changedelete = { text = "~" },
       },
       on_attach = function(bufnr)
-        local gs = package.loaded.gitsigns
+        local gs = require("gitsigns")
         local map = function(mode, lhs, rhs, opts)
           opts = opts or {}
           opts.buffer = bufnr

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -69,14 +69,9 @@ return {
           end
           map("n", "gd", vim.lsp.buf.definition, "Go to definition")
           map("n", "gD", vim.lsp.buf.type_definition, "Type definition")
-          map("n", "gr", vim.lsp.buf.references, "References")
-          map("n", "gi", vim.lsp.buf.implementation, "Implementation")
-          map("n", "K", vim.lsp.buf.hover, "Hover")
           map("n", "<leader>ca", vim.lsp.buf.code_action, "Code action")
           map("n", "<leader>rn", vim.lsp.buf.rename, "Rename")
           map("n", "<leader>e", vim.diagnostic.open_float, "Diagnostics float")
-          map("n", "]d", function() vim.diagnostic.jump({ count = 1 }) end, "Next diagnostic")
-          map("n", "[d", function() vim.diagnostic.jump({ count = -1 }) end, "Prev diagnostic")
           map("n", "cmt", "<cmd>Telescope lsp_document_symbols<cr>", "Document symbols")
         end,
       })

--- a/picom/picom.conf
+++ b/picom/picom.conf
@@ -23,7 +23,10 @@ opacity-rule = [
   "100:class_g *= 'Shadow PC'",
 ];
 
-blur-kern = "3x3box";
+blur: {
+  method = "box";
+  size = 3;
+};
 blur-background-exclude = [];
 
 backend = "glx";

--- a/ranger/scope.sh
+++ b/ranger/scope.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o noclobber -o noglob -o nounset -o pipefail
 IFS=$'\n'

--- a/shadow/shadow-pc.desktop
+++ b/shadow/shadow-pc.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=Shadow PC
 Comment=Shadow cloud gaming
-Exec=nix-shell /home/sascha/games/shadow/shell.nix
+Exec=sh -c 'nix-shell ~/games/shadow/shell.nix'
 Terminal=false
 Categories=Game;

--- a/shadow/shell.nix
+++ b/shadow/shell.nix
@@ -37,7 +37,7 @@ pkgs.mkShell {
     done
     sudo ${usbipd} -D
 
-    appimage-run /home/sascha/games/shadow/ShadowPC.AppImage
+    appimage-run $HOME/games/shadow/ShadowPC.AppImage
 
     # Cleanup USB/IP
     for busid in $USBIP_BUSIDS; do

--- a/x11/xinitrc
+++ b/x11/xinitrc
@@ -1,2 +1,3 @@
 xset b off
+xrdb -merge ~/.Xdefaults
 exec i3


### PR DESCRIPTION
- Ranger: fix shebang for NixOS (`#!/usr/bin/env bash`)
- NixOS: remove redundant `auto-optimise-store` (timer-based `optimise.automatic` is sufficient), remove world-writable backlight udev rule (`programs.light` handles this via video group)
- Neovim: remove redundant 0.10+/0.11+ defaults (`termguicolors`, `fillchars` vert, `Q` macro replay, last-position-jump autocmd, `K`/`gr`/`gi`/`]d`/`[d` LSP mappings), use `require("gitsigns")` instead of fragile `package.loaded` lookup
- i3: use `systemctl poweroff` instead of `sudo shutdown`
- Picom: replace deprecated `blur-kern` with modern `blur` config
- x11: load Xdefaults via `xrdb -merge` before starting i3
- Shadow: replace hardcoded `/home/sascha/` paths with `~` and `$HOME`
- Makefile: rename `USER` to `GIT_USER` to avoid shadowing Make built-in