### PR TITLE
Improve dotfiles across all tool configs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -11,6 +14,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
@@ -19,6 +23,7 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
@@ -27,6 +32,7 @@ jobs:
 
   prettier:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0 # v4.6
@@ -36,24 +42,28 @@ jobs:
 
   typos:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
 
   markdown-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0
 
   shellcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
 
   shfmt:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: mfinelli/setup-shfmt@a25fda4c1fe115aec0f85e04126610841bc3141d # v4.0.1

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@
 *.py
 *.pyc
 flake.lock
+nvim/lazy-lock.json

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ COLOR := \033[36m
 NOCOLOR := \033[0m
 
 .SILENT:
-.PHONY: all build switch gitconfig-user update upgrade check check-nix lint lint-fix help
+.PHONY: all build switch gitconfig-user update upgrade check check-nix lint lint-fix test help
 
 ##@ Build targets:
 
@@ -60,14 +60,19 @@ check-nix: ## Run nix flake checks.
 	nix flake check
 
 lint: ## Check formatting and lint all Nix files.
-	nix run nixpkgs\#nixpkgs-fmt -- --check $$(find . -name '*.nix')
+	nix run nixpkgs\#nixfmt -- --check $$(find . -name '*.nix')
 	nix run nixpkgs\#statix -- check .
 	nix run nixpkgs\#deadnix -- $$(find . -name '*.nix')
 
 lint-fix: ## Fix formatting and lint issues in all Nix files.
-	nix run nixpkgs\#nixpkgs-fmt -- $$(find . -name '*.nix')
+	nix run nixpkgs\#nixfmt -- $$(find . -name '*.nix')
 	nix run nixpkgs\#statix -- fix .
 	nix run nixpkgs\#deadnix -- -e $$(find . -name '*.nix')
+
+test: lint check-nix ## Run checks locally.
+	prettier --check .
+	typos
+	shfmt -d .
 
 ##@ Update targets:
 

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -35,7 +35,7 @@ blinking = "Off"
 unfocused_hollow = true
 
 [env]
-TERM = "xterm-256color"
+TERM = "alacritty"
 
 [font]
 size = 9.0
@@ -74,7 +74,7 @@ semantic_escape_chars = ",│`|:\"' ()[]{}<>"
 [window]
 decorations = "full"
 dynamic_padding = false
-dynamic_title = false
+dynamic_title = true
 opacity = 1
 
 [window.dimensions]

--- a/dunst/dunstrc
+++ b/dunst/dunstrc
@@ -4,7 +4,7 @@
     origin = top-right
     offset = 30x20
     notification_limit = 10
-    font = Sans 8
+    font = MesloLGSDZ Nerd Font 8
     format = "<b>%s</b>\n%b"
     alignment = left
     markup = full

--- a/fish/aliases.fish
+++ b/fish/aliases.fish
@@ -3,70 +3,70 @@ alias ... "cd ../.."
 alias .... "cd ../../.."
 alias ..... "cd ../../../.."
 command -q bat && alias cat "bat"
-alias cl "claude"
-alias duf "du -sh *"
-alias f "fd"
-alias ff "fd --type f"
-alias g "git"
-alias ga "git add"
-alias gaa "git add -A"
-alias gb "git branch"
-alias gba "git branch -a"
-alias gbv "git branch -vv"
-alias gca "git commit -s --amend"
-alias gcan "git commit -s --amend --no-edit"
-alias gcaa "git commit -s -a --amend --no-edit"
-alias gcl "git clone"
-alias gcmsg "git commit -sm"
-alias gco "git checkout"
-alias gd "git diff"
-alias gdc "git diff --cached"
-alias glg "git log --stat --max-count=10"
-alias glgg "git log --graph --max-count=10"
-alias glgga "git log --graph --decorate --all"
-alias glo "git log --oneline --decorate --color"
-alias glog "git log --oneline --decorate --color --graph"
-alias glr "git pull --rebase"
-alias gm "git merge"
-alias gmn "git merge --no-ff"
-alias gp "git push"
-alias gpf "git push --force-with-lease"
-alias gr "git reset ."
-alias grc "git rebase --continue"
-alias grup "git remote update"
-alias gupb "gup base"
-alias grv "git remote -v"
-alias gsp "git stash pop"
-alias gss "git stash"
-alias gst "git status"
-alias ghn "gh api -X PUT notifications --silent"
-alias h "history"
-alias hs "history --search"
-alias k "kubectl"
-alias kk "kubectl config use-context"
-alias l "ls -l"
-alias la "ls -a"
-alias ll "l -a"
-alias llt "ll -T"
 command -q eza && alias ls "eza --git -bgF"
-alias lt "l -T"
-alias m "make"
-alias mc "make clean"
-alias md "mkdir -p"
+
+abbr -a cl claude
+abbr -a dush du -sh \*
+abbr -a f fd
+abbr -a ff fd --type f
+abbr -a g git
+abbr -a ga git add
+abbr -a gaa git add -A
+abbr -a gb git branch
+abbr -a gba git branch -a
+abbr -a gbv git branch -vv
+abbr -a gca git commit -s --amend
+abbr -a gcan git commit -s --amend --no-edit
+abbr -a gcaa git commit -s -a --amend --no-edit
+abbr -a gcl git clone
+abbr -a gcmsg git commit -sm
+abbr -a gco git checkout
+abbr -a gd git diff
+abbr -a gdc git diff --cached
+abbr -a glg git log --stat --max-count=10
+abbr -a glgg git log --graph --max-count=10
+abbr -a glgga git log --graph --decorate --all
+abbr -a glo git log --oneline --decorate --color
+abbr -a glog git log --oneline --decorate --color --graph
+abbr -a glr git pull --rebase
+abbr -a gm git merge
+abbr -a gmn git merge --no-ff
+abbr -a gp git push
+abbr -a gpf git push --force-with-lease
+abbr -a gr git reset .
+abbr -a grc git rebase --continue
+abbr -a grup git remote update
+abbr -a gupb gup base
+abbr -a grv git remote -v
+abbr -a gsp git stash pop
+abbr -a gss git stash
+abbr -a gst git status
+abbr -a ghn gh api -X PUT notifications --silent
+abbr -a h history
+abbr -a hs history --search
+abbr -a k kubectl
+abbr -a kk kubectl config use-context
+abbr -a l ls -l
+abbr -a la ls -a
+abbr -a ll ls -la
+abbr -a llt ls -laT
+abbr -a lt ls -lT
+abbr -a m make
+abbr -a mc make clean
+abbr -a md mkdir -p
 alias mm "make -j(nproc)"
-alias nup "nix flake update --flake $DOTFILES"
-alias p "pwd"
-alias po "popd"
-alias pu "pushd"
-alias r "rm -rf"
-alias rup "rustup update"
-alias screensleep "xset dpms force off"
-alias t "tail -f"
-alias ta "tmux attach"
-alias tg "cd ~ && tmux"
-alias tl "tmux list-sessions"
-alias ts "tmux new-session -s"
-alias up "rup && sudo nixos-rebuild switch --flake $DOTFILES#nixos && nix develop $DOTFILES --command true && nix-collect-garbage --delete-older-than 7d"
-alias v "nvim"
-alias vr "ranger"
-alias vv "nvim -u NONE"
+abbr -a nup nix flake update --flake \$DOTFILES
+abbr -a p pwd
+abbr -a po popd
+abbr -a pu pushd
+abbr -a rup rustup update
+abbr -a screensleep xset dpms force off
+abbr -a t tail -f
+abbr -a ta tmux attach
+abbr -a tg cd \~ \&\& tmux
+abbr -a tl tmux list-sessions
+abbr -a ts tmux new-session -s
+abbr -a up rustup update \&\& sudo nixos-rebuild switch --flake \$DOTFILES\#nixos \&\& nix develop \$DOTFILES --command true \&\& nix-collect-garbage --delete-older-than 7d
+abbr -a v nvim
+abbr -a vr ranger
+abbr -a vv nvim -u NONE

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -49,7 +49,10 @@ function fish_greeting; end
 function fish_title; end
 function fish_mode_prompt; end
 
-fish_config theme choose "Dracula"
+if not set -q __fish_theme_configured
+    fish_config theme choose "Dracula"
+    set -U __fish_theme_configured 1
+end
 
 if functions -q fish_vi_key_bindings
     function fish_user_key_bindings

--- a/fish/functions/gpl.fish
+++ b/fish/functions/gpl.fish
@@ -1,6 +1,6 @@
 # Prune local branches that are gone on remote
 function gpl
-    for branch in (git branch -vv | grep ': gone]' | awk '{print $1}')
+    for branch in (git branch -vv | grep ': gone]' | awk '{print $1}' | grep -v '^\*')
         git branch -D $branch
     end
 end

--- a/fish/functions/gpr.fish
+++ b/fish/functions/gpr.fish
@@ -1,5 +1,8 @@
 # Fetch and checkout GitHub PR
 function gpr
-    test (count $argv) -eq 2 || return 1
+    test (count $argv) -eq 2 || begin
+        echo "Usage: gpr <remote> <pr-number>" >&2
+        return 1
+    end
     git fetch $argv[1] pull/$argv[2]/head:pr-$argv[2] && git checkout pr-$argv[2]
 end

--- a/fish/functions/grinse.fish
+++ b/fish/functions/grinse.fish
@@ -1,5 +1,8 @@
 # Deep clean git repo and submodules
 function grinse
+    echo "This will destroy all uncommitted changes. Continue? [y/N]"
+    read -l confirm
+    test "$confirm" = y || test "$confirm" = Y || return 1
     git clean -xfd
     and git submodule foreach --recursive git clean -xfd
     and git reset --hard

--- a/fish/functions/gsq.fish
+++ b/fish/functions/gsq.fish
@@ -1,4 +1,9 @@
 # Squash commits since merge base
 function gsq
-    git reset (gmb) && gaa && git commit -s
+    set -l base (gmb)
+    test -n "$base" || begin
+        echo "Failed to determine merge base" >&2
+        return 1
+    end
+    git reset $base && git add -A && git commit -s
 end

--- a/fish/functions/gup.fish
+++ b/fish/functions/gup.fish
@@ -2,5 +2,5 @@
 function gup
     set -l remote $argv[1]
     test -z "$remote" && set remote origin
-    git fetch $remote && git merge $remote/(gldb) && gp && gl
+    git fetch $remote && git merge $remote/(gldb) && git push && gl
 end

--- a/fish/functions/kns.fish
+++ b/fish/functions/kns.fish
@@ -1,4 +1,8 @@
 # Set kubernetes namespace
 function kns
+    test (count $argv) -eq 1 || begin
+        echo "Usage: kns <namespace>" >&2
+        return 1
+    end
     kubectl config set-context --current --namespace=$argv[1]
 end

--- a/fish/functions/nb.fish
+++ b/fish/functions/nb.fish
@@ -1,6 +1,6 @@
 # Build nix package
 function nb
     set -l PKG (basename "$PWD")
-    test (count $argv) -gt 0 && set PKG "$argv"
+    test (count $argv) -gt 0 && set PKG $argv[1]
     nix build --impure --expr "with import (builtins.getFlake \"nixpkgs\") {}; $PKG.overrideAttrs { src = ./.; }"
 end

--- a/fish/functions/tailc.fish
+++ b/fish/functions/tailc.fish
@@ -1,5 +1,10 @@
 # Tail curl output with auto-refresh
 function tailc
+    test (count $argv) -ge 1 || begin
+        echo "Usage: tailc <url>" >&2
+        return 1
+    end
     set -l lines (math (tput lines) - 2)
-    watch -n1 "curl -sf '$argv[1]' | tail -n $lines"
+    set -l escaped_url (string replace -a "'" "'\\''" -- $argv[1])
+    watch -n1 "curl -sf '$escaped_url' | tail -n $lines"
 end

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,8 @@
     };
   };
 
-  outputs = { nixpkgs, home-manager, ... }:
+  outputs =
+    { nixpkgs, home-manager, ... }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
@@ -34,7 +35,7 @@
         ];
       };
 
-      formatter.${system} = pkgs.nixpkgs-fmt;
+      formatter.${system} = pkgs.nixfmt;
 
       devShells.${system}.default = pkgs.mkShell {
         buildInputs = with pkgs; [

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -31,6 +31,11 @@
     prune = true
 [rebase]
     autostash = true
+    autosquash = true
+[column]
+    ui = auto
+[branch]
+    sort = -committerdate
 [rerere]
     enabled = 1
 [filter "lfs"]

--- a/git/gitignore_global
+++ b/git/gitignore_global
@@ -2,8 +2,11 @@ cscope.*
 tags
 *.swp
 *.swo
+*.orig
 .DS_Store
 .vscode/
 .idea/
 .env
 .env.local
+.direnv/
+result

--- a/home.nix
+++ b/home.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, dotfilesPath, ... }:
+{
+  config,
+  pkgs,
+  dotfilesPath,
+  ...
+}:
 let
   link = config.lib.file.mkOutOfStoreSymlink;
 in

--- a/i3/setup
+++ b/i3/setup
@@ -4,5 +4,5 @@ set -euo pipefail
 i3-msg exec setup-screens
 
 # Setup default applications
-i3-msg exec "alacritty -e fish -C \"tmux new-session -s work\""
+i3-msg exec "alacritty -e fish -C \"tmux new-session -s work\" || xterm"
 i3-msg exec "google-chrome-stable --force-device-scale-factor=1.5"

--- a/i3status-rust/config.toml
+++ b/i3status-rust/config.toml
@@ -33,7 +33,7 @@ format = " $icon $used/$total ($available)"
 
 [[block]]
 block = "temperature"
-interval = 1
+interval = 5
 format = " $average C "
 chip = "*-isa-*"
 
@@ -42,7 +42,7 @@ block = "net"
 # Hardware-specific: adjust per machine
 device = "wlp1s0"
 format = " $speed_down $speed_up "
-interval = 1
+interval = 5
 
 [[block]]
 block = "memory"
@@ -50,7 +50,7 @@ format = "$mem_used / $mem_total ($mem_used_percents) "
 
 [[block]]
 block = "cpu"
-interval = 1
+interval = 5
 format = " $utilization ($frequency) "
 
 [[block]]

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -16,10 +16,15 @@
 
   nix = {
     settings = {
-      auto-optimise-store = true;
-      experimental-features = [ "nix-command" "flakes" ];
+      experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
       max-jobs = "auto";
-      trusted-users = [ "root" "sascha" ];
+      trusted-users = [
+        "root"
+        "sascha"
+      ];
     };
 
     optimise.automatic = true;

--- a/nixos/hosts/desktop/hardware.nix
+++ b/nixos/hosts/desktop/hardware.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   fileSystems = {
     "/" = {
       device = "/dev/disk/by-uuid/f436cabf-2f00-4ca2-aa5f-bebbeffb3a18";
@@ -8,11 +7,14 @@ _:
     "/boot" = {
       device = "/dev/disk/by-uuid/BA23-E4AC";
       fsType = "vfat";
-      options = [ "fmask=0022" "dmask=0022" ];
+      options = [
+        "fmask=0022"
+        "dmask=0022"
+      ];
     };
   };
 
-  swapDevices = [{ device = "/dev/disk/by-uuid/7b5f80d4-b31d-4619-b8c4-c3fcae0441a9"; }];
+  swapDevices = [ { device = "/dev/disk/by-uuid/7b5f80d4-b31d-4619-b8c4-c3fcae0441a9"; } ];
 
   environment.variables = {
     GDK_SCALE = "2";

--- a/nixos/packages.nix
+++ b/nixos/packages.nix
@@ -6,7 +6,6 @@
     # Desktop & UI
     alacritty
     arandr
-    arc-theme
     dmenu
     dunst
     feh
@@ -14,7 +13,6 @@
     j4-dmenu-desktop
     lxappearance
     pavucontrol
-    picom
     xclip
     xdg-utils
     xev
@@ -158,7 +156,7 @@
     nix-index
     nix-prefetch-git
     nixos-shell
-    nixpkgs-fmt
+    nixfmt
 
     # Misc
     bom

--- a/nixos/packages/usbip-host-patched.nix
+++ b/nixos/packages/usbip-host-patched.nix
@@ -1,4 +1,8 @@
-{ stdenv, lib, kernel }:
+{
+  stdenv,
+  lib,
+  kernel,
+}:
 
 stdenv.mkDerivation {
   pname = "usbip-host-patched";

--- a/nixos/programs.nix
+++ b/nixos/programs.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   programs = {
     bcc.enable = true;
     fish.enable = true;

--- a/nixos/security.nix
+++ b/nixos/security.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   security = {
     krb5 = {
       enable = true;

--- a/nixos/services.nix
+++ b/nixos/services.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   services = {
     autorandr.enable = true;

--- a/nixos/virtualisation.nix
+++ b/nixos/virtualisation.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   virtualisation = {
     containers = {
       enable = true;

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -1,178 +1,46 @@
 {
-  "LuaSnip": {
-    "branch": "master",
-    "commit": "0abc8f390b278c3b4aabc4c004ac8a088b65cf24"
-  },
-  "bufferline.nvim": {
-    "branch": "main",
-    "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3"
-  },
-  "cmp-buffer": {
-    "branch": "main",
-    "commit": "b74fab3656eea9de20a9b8116afa3cfc4ec09657"
-  },
-  "cmp-cmdline": {
-    "branch": "main",
-    "commit": "d126061b624e0af6c3a556428712dd4d4194ec6d"
-  },
-  "cmp-nvim-lsp": {
-    "branch": "main",
-    "commit": "cbc7b02bb99fae35cb42f514762b89b5126651ef"
-  },
-  "cmp-path": {
-    "branch": "main",
-    "commit": "c642487086dbd9a93160e1679a1327be111cbc25"
-  },
-  "cmp_luasnip": {
-    "branch": "master",
-    "commit": "98d9cb5c2c38532bd9bdb481067b20fea8f32e90"
-  },
-  "conform.nvim": {
-    "branch": "master",
-    "commit": "619363c30309d29ffa631e67c8183f2a72caa373"
-  },
-  "dracula.nvim": {
-    "branch": "main",
-    "commit": "ae752c13e95fb7c5f58da4b5123cb804ea7568ee"
-  },
-  "friendly-snippets": {
-    "branch": "main",
-    "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9"
-  },
-  "gitsigns.nvim": {
-    "branch": "main",
-    "commit": "eb60cc7b94c46005237fd34170d76f3a089a90aa"
-  },
-  "lazy.nvim": {
-    "branch": "main",
-    "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97"
-  },
-  "lualine.nvim": {
-    "branch": "master",
-    "commit": "221ce6b2d999187044529f49da6554a92f740a96"
-  },
-  "mason-lspconfig.nvim": {
-    "branch": "main",
-    "commit": "47059d71b42d74b0a1e9f61c1d99d301039c3b5b"
-  },
-  "mason.nvim": {
-    "branch": "main",
-    "commit": "2a6940af80375532e5e9e7c1f2fc6319a1b7a69d"
-  },
-  "nvim-autopairs": {
-    "branch": "master",
-    "commit": "7b9923abad60b903ece7c52940e1321d39eccc79"
-  },
-  "nvim-cmp": {
-    "branch": "main",
-    "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca"
-  },
-  "nvim-dap": {
-    "branch": "master",
-    "commit": "9e848e09a697ee95302a3ef2dd43fd6eb709e570"
-  },
-  "nvim-dap-go": {
-    "branch": "main",
-    "commit": "b4421153ead5d726603b02743ea40cf26a51ed5f"
-  },
-  "nvim-dap-python": {
-    "branch": "master",
-    "commit": "1808458eba2b18f178f990e01376941a42c7f93b"
-  },
-  "nvim-dap-ui": {
-    "branch": "master",
-    "commit": "1a66cabaa4a4da0be107d5eda6d57242f0fe7e49"
-  },
-  "nvim-lint": {
-    "branch": "master",
-    "commit": "a219b2c9e5b4765e5c845aba119dad55806fcaf1"
-  },
-  "nvim-lspconfig": {
-    "branch": "master",
-    "commit": "d224a1920728ba129880efc700d4a0180ac4ecbb"
-  },
-  "nvim-nio": {
-    "branch": "master",
-    "commit": "21f5324bfac14e22ba26553caf69ec76ae8a7662"
-  },
-  "nvim-treesitter": {
-    "branch": "main",
-    "commit": "4916d6592ede8c07973490d9322f187e07dfefac"
-  },
-  "nvim-web-devicons": {
-    "branch": "master",
-    "commit": "dad71387de386a946b123079d0e53f23028f3abd"
-  },
-  "plenary.nvim": {
-    "branch": "master",
-    "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b"
-  },
-  "targets.vim": {
-    "branch": "master",
-    "commit": "6325416da8f89992b005db3e4517aaef0242602e"
-  },
-  "telescope-fzf-native.nvim": {
-    "branch": "main",
-    "commit": "b25b749b9db64d375d782094e2b9dce53ad53a40"
-  },
-  "telescope.nvim": {
-    "branch": "master",
-    "commit": "427b576c16792edad01a92b89721d923c19ad60f"
-  },
-  "tmuxline.vim": {
-    "branch": "master",
-    "commit": "4119c553923212cc67f4e135e6f946dc3ec0a4d6"
-  },
-  "undotree": {
-    "branch": "master",
-    "commit": "6fa6b57cda8459e1e4b2ca34df702f55242f4e4d"
-  },
-  "vim-abolish": {
-    "branch": "master",
-    "commit": "dcbfe065297d31823561ba787f51056c147aa682"
-  },
-  "vim-easymotion": {
-    "branch": "master",
-    "commit": "b3cfab2a6302b3b39f53d9fd2cd997e1127d7878"
-  },
-  "vim-eunuch": {
-    "branch": "master",
-    "commit": "e86bb794a1c10a2edac130feb0ea590a00d03f1e"
-  },
-  "vim-exchange": {
-    "branch": "master",
-    "commit": "d6c1e9790bcb8df27c483a37167459bbebe0112e"
-  },
-  "vim-fugitive": {
-    "branch": "master",
-    "commit": "3b753cf8c6a4dcde6edee8827d464ba9b8c4a6f0"
-  },
-  "vim-repeat": {
-    "branch": "master",
-    "commit": "65846025c15494983dafe5e3b46c8f88ab2e9635"
-  },
-  "vim-schlepp": {
-    "branch": "master",
-    "commit": "dfe67ad49d534e6c442d589c558da7b3ab052f03"
-  },
-  "vim-speeddating": {
-    "branch": "master",
-    "commit": "c17eb01ebf5aaf766c53bab1f6592710e5ffb796"
-  },
-  "vim-surround": {
-    "branch": "master",
-    "commit": "3d188ed2113431cf8dac77be61b842acb64433d9"
-  },
-  "vim-tmux-navigator": {
-    "branch": "master",
-    "commit": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432"
-  },
-  "vim-unimpaired": {
-    "branch": "master",
-    "commit": "db65482581a28e4ccf355be297f1864a4e66985c"
-  },
-  "which-key.nvim": {
-    "branch": "main",
-    "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a"
-  }
+  "LuaSnip": { "branch": "master", "commit": "0abc8f390b278c3b4aabc4c004ac8a088b65cf24" },
+  "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
+  "cmp-buffer": { "branch": "main", "commit": "b74fab3656eea9de20a9b8116afa3cfc4ec09657" },
+  "cmp-cmdline": { "branch": "main", "commit": "d126061b624e0af6c3a556428712dd4d4194ec6d" },
+  "cmp-nvim-lsp": { "branch": "main", "commit": "cbc7b02bb99fae35cb42f514762b89b5126651ef" },
+  "cmp-path": { "branch": "main", "commit": "c642487086dbd9a93160e1679a1327be111cbc25" },
+  "cmp_luasnip": { "branch": "master", "commit": "98d9cb5c2c38532bd9bdb481067b20fea8f32e90" },
+  "conform.nvim": { "branch": "master", "commit": "619363c30309d29ffa631e67c8183f2a72caa373" },
+  "dracula.nvim": { "branch": "main", "commit": "ae752c13e95fb7c5f58da4b5123cb804ea7568ee" },
+  "flash.nvim": { "branch": "main", "commit": "fcea7ff883235d9024dc41e638f164a450c14ca2" },
+  "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
+  "gitsigns.nvim": { "branch": "main", "commit": "eb60cc7b94c46005237fd34170d76f3a089a90aa" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "lualine.nvim": { "branch": "master", "commit": "221ce6b2d999187044529f49da6554a92f740a96" },
+  "mason-lspconfig.nvim": { "branch": "main", "commit": "47059d71b42d74b0a1e9f61c1d99d301039c3b5b" },
+  "mason.nvim": { "branch": "main", "commit": "2a6940af80375532e5e9e7c1f2fc6319a1b7a69d" },
+  "nvim-autopairs": { "branch": "master", "commit": "7b9923abad60b903ece7c52940e1321d39eccc79" },
+  "nvim-cmp": { "branch": "main", "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca" },
+  "nvim-dap": { "branch": "master", "commit": "9e848e09a697ee95302a3ef2dd43fd6eb709e570" },
+  "nvim-dap-go": { "branch": "main", "commit": "b4421153ead5d726603b02743ea40cf26a51ed5f" },
+  "nvim-dap-python": { "branch": "master", "commit": "1808458eba2b18f178f990e01376941a42c7f93b" },
+  "nvim-dap-ui": { "branch": "master", "commit": "1a66cabaa4a4da0be107d5eda6d57242f0fe7e49" },
+  "nvim-lint": { "branch": "master", "commit": "a219b2c9e5b4765e5c845aba119dad55806fcaf1" },
+  "nvim-lspconfig": { "branch": "master", "commit": "d224a1920728ba129880efc700d4a0180ac4ecbb" },
+  "nvim-nio": { "branch": "master", "commit": "21f5324bfac14e22ba26553caf69ec76ae8a7662" },
+  "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
+  "nvim-web-devicons": { "branch": "master", "commit": "dad71387de386a946b123079d0e53f23028f3abd" },
+  "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "targets.vim": { "branch": "master", "commit": "6325416da8f89992b005db3e4517aaef0242602e" },
+  "telescope-fzf-native.nvim": { "branch": "main", "commit": "b25b749b9db64d375d782094e2b9dce53ad53a40" },
+  "telescope.nvim": { "branch": "master", "commit": "427b576c16792edad01a92b89721d923c19ad60f" },
+  "tmuxline.vim": { "branch": "master", "commit": "4119c553923212cc67f4e135e6f946dc3ec0a4d6" },
+  "undotree": { "branch": "master", "commit": "6fa6b57cda8459e1e4b2ca34df702f55242f4e4d" },
+  "vim-abolish": { "branch": "master", "commit": "dcbfe065297d31823561ba787f51056c147aa682" },
+  "vim-eunuch": { "branch": "master", "commit": "e86bb794a1c10a2edac130feb0ea590a00d03f1e" },
+  "vim-exchange": { "branch": "master", "commit": "d6c1e9790bcb8df27c483a37167459bbebe0112e" },
+  "vim-fugitive": { "branch": "master", "commit": "3b753cf8c6a4dcde6edee8827d464ba9b8c4a6f0" },
+  "vim-repeat": { "branch": "master", "commit": "65846025c15494983dafe5e3b46c8f88ab2e9635" },
+  "vim-schlepp": { "branch": "master", "commit": "dfe67ad49d534e6c442d589c558da7b3ab052f03" },
+  "vim-speeddating": { "branch": "master", "commit": "c17eb01ebf5aaf766c53bab1f6592710e5ffb796" },
+  "vim-surround": { "branch": "master", "commit": "3d188ed2113431cf8dac77be61b842acb64433d9" },
+  "vim-tmux-navigator": { "branch": "master", "commit": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432" },
+  "vim-unimpaired": { "branch": "master", "commit": "db65482581a28e4ccf355be297f1864a4e66985c" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
 }

--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -44,10 +44,12 @@ opt.foldnestmax = 20
 
 -- Persistent undo
 local backupdir = vim.fn.stdpath("data") .. "/backups"
+local swapdir = vim.fn.stdpath("data") .. "/swap"
 vim.fn.mkdir(backupdir, "p")
+vim.fn.mkdir(swapdir, "p")
 opt.undodir = backupdir
 opt.backupdir = backupdir
-opt.directory = "/tmp"
+opt.directory = swapdir
 opt.undofile = true
 opt.swapfile = true
 opt.backup = true

--- a/nvim/lua/plugins/navigation.lua
+++ b/nvim/lua/plugins/navigation.lua
@@ -1,45 +1,23 @@
 return {
   {
-    "easymotion/vim-easymotion",
+    "folke/flash.nvim",
     event = "VeryLazy",
-    init = function()
-      vim.g.EasyMotion_smartcase = 1
-      vim.g.EasyMotion_enter_jump_first = 1
-      vim.g.EasyMotion_space_jump_first = 1
-      vim.g.EasyMotion_move_highlight = 0
-      vim.g.EasyMotion_startofline = 0
-    end,
+    opts = {
+      modes = {
+        char = {
+          jump_labels = true,
+        },
+        search = {
+          enabled = false,
+        },
+      },
+    },
     keys = {
-      { "s", "<Plug>(easymotion-overwin-f2)", mode = "n" },
-      { "s", "<Plug>(easymotion-s2)", mode = "x" },
-      { "z", "<Plug>(easymotion-s2)", mode = "o" },
-
-      { "S", "<Plug>(easymotion-sn)", mode = "n" },
-      { "Z", "<Plug>(easymotion-sn)", mode = { "x", "o" } },
-
-      { "<leader><leader>S", "<Plug>(easymotion-jumptoanywhere)", mode = { "n", "x", "o" } },
-
-      { "f", "<Plug>(easymotion-fl)", mode = { "n", "x", "o" } },
-      { "F", "<Plug>(easymotion-Fl)", mode = { "n", "x", "o" } },
-
-      { "t", "<Plug>(easymotion-tl)", mode = { "x", "o" } },
-      { "T", "<Plug>(easymotion-Tl)", mode = { "x", "o" } },
-
-      { ",", "<Plug>(easymotion-next)", mode = "n" },
-      { ";", "<Plug>(easymotion-prev)", mode = "n" },
-
-      { "j", "<Plug>(easymotion-j)", mode = "n" },
-      { "k", "<Plug>(easymotion-k)", mode = "n" },
-      { "l", "<Plug>(easymotion-lineforward)", mode = "n" },
-      { "h", "<Plug>(easymotion-linebackward)", mode = "n" },
-
-      { "<leader>j", "<Plug>(easymotion-j)", mode = "v" },
-      { "<leader>k", "<Plug>(easymotion-k)", mode = "v" },
-      { "<leader>h", "<Plug>(easymotion-linebackward)", mode = "v" },
-      { "<leader>l", "<Plug>(easymotion-lineforward)", mode = "v" },
-
-      { "<leader><leader>J", "<Plug>(easymotion-eol-j)" },
-      { "<leader><leader>K", "<Plug>(easymotion-eol-k)" },
+      { "s", mode = { "n", "x", "o" }, function() require("flash").jump() end },
+      { "S", mode = { "n", "o" }, function() require("flash").treesitter() end },
+      { "r", mode = "o", function() require("flash").remote() end },
+      { "R", mode = { "o", "x" }, function() require("flash").treesitter_search() end },
+      { "<c-s>", mode = { "c" }, function() require("flash").toggle() end },
     },
   },
 }

--- a/shadow/shell.nix
+++ b/shadow/shell.nix
@@ -1,4 +1,6 @@
-{ pkgs ? import <nixpkgs> { } }:
+{
+  pkgs ? import <nixpkgs> { },
+}:
 
 let
   appimage-run-shadow = pkgs.appimage-run.override {

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -18,10 +18,16 @@ bind-key C-c command-prompt -p "Project:" "new-window -n '%%'"
 
 setw -g aggressive-resize on
 
-set -g status-interval 1
+set -g status-interval 5
 
 set -g default-terminal "tmux-256color"
 set -ga terminal-overrides ",xterm-256color:Tc"
+set -ga terminal-overrides ",alacritty:Tc"
+set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'
+set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
+
+set -g focus-events on
+set -g renumber-windows on
 
 is_vim='echo "#{pane_current_command}" | grep -iqE "(^|\/)g?(view|n?vim?)(diff)?$"'
 bind -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"


### PR DESCRIPTION
- Fish: convert aliases to abbreviations for better history, fix tailc
  shell injection, add confirmation to grinse, add argument validation
  to functions, apply Dracula theme only on first run
- Neovim: replace vim-easymotion with flash.nvim, move swap files to
  private directory
- Git: add autosquash, column.ui, branch.sort; expand gitignore
- Tmux: add focus-events, renumber-windows, undercurl support,
  true-color override for alacritty TERM
- Nix: remove redundant auto-optimise-store and duplicate packages
  (arc-theme, picom), replace deprecated nixpkgs-fmt with
  nixfmt-rfc-style
- CI: add permissions block and timeout-minutes to all jobs
- Reduce i3status-rust polling intervals, match dunst font to desktop
  theme, enable alacritty dynamic_title, set correct TERM value, add
  Makefile test target, add i3 setup terminal fallback, exclude
  lazy-lock.json from prettier