### PR TITLE
Fix deprecated configs, remove dead code, wire up yamllint

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ in `flake.nix`.
 ```fish
 > git clone https://github.com/saschagrunert/dotfiles ~/.dotfiles
 > cd ~/.dotfiles
-> make gitconfig-user USER="John Doe" EMAIL="john@doe.com" SIGNKEY="123"
+> make gitconfig-user GIT_USER="John Doe" EMAIL="john@doe.com" SIGNKEY="123"
 > sudo nixos-rebuild switch --flake ~/.dotfiles#nixos
 ```
 

--- a/dunst/dunstrc
+++ b/dunst/dunstrc
@@ -2,7 +2,7 @@
     width = 300
     height = (0, 300)
     origin = top-right
-    offset = 30x20
+    offset = (30, 20)
     notification_limit = 10
     font = MesloLGSDZ Nerd Font 8
     format = "<b>%s</b>\n%b"

--- a/nixos/packages.nix
+++ b/nixos/packages.nix
@@ -140,7 +140,6 @@
     lshw
     lvm2
     pahole
-    sysstat
     usbutils
     valgrind
 

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -20,4 +20,5 @@ require("lazy").setup("plugins", {
   install = { colorscheme = { "dracula" } },
   change_detection = { notify = false },
   git = { url_format = "git@github.com:%s.git" },
+  rocks = { enabled = false },
 })

--- a/nvim/lua/config/autocmds.lua
+++ b/nvim/lua/config/autocmds.lua
@@ -81,8 +81,8 @@ autocmd("BufWritePost", {
 -- Run commands per filetype
 local ft_runner_group = augroup("FiletypeRunners", { clear = true })
 local ft_runners = {
-  bash = "bash", javascript = "node", perl = "perl",
-  php = "php", python = "python", ruby = "ruby", sh = "sh",
+  bash = "bash", javascript = "node",
+  python = "python", sh = "sh",
 }
 for ft, cmd in pairs(ft_runners) do
   autocmd("FileType", {

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -100,8 +100,8 @@ map("n", "zh", "zH")
 map("i", "jj", "<ESC>")
 
 -- Blank lines
-map("n", "<leader>d", "m`:silent +g/\\m^\\s*$/d<CR>``:noh<CR>", { silent = true })
-map("n", "<leader>D", "m`:silent -g/\\m^\\s*$/d<CR>``:noh<CR>", { silent = true })
+map("n", "<leader>dd", "m`:silent +g/\\m^\\s*$/d<CR>``:noh<CR>", { silent = true })
+map("n", "<leader>dD", "m`:silent -g/\\m^\\s*$/d<CR>``:noh<CR>", { silent = true })
 map("n", "<leader>o", "m`o<Esc>``", { silent = true })
 map("n", "<leader>O", "m`O<Esc>``", { silent = true })
 

--- a/nvim/lua/plugins/editing.lua
+++ b/nvim/lua/plugins/editing.lua
@@ -80,7 +80,6 @@ return {
       { "l", "<Plug>SchleppRight", mode = "v" },
       { "<S-up>", "<Plug>SchleppIndentUp", mode = "v" },
       { "<S-down>", "<Plug>SchleppIndentDown", mode = "v" },
-      { "D", "<Plug>SchleppDup", mode = "v" },
       { "Dk", "<Plug>SchleppDupUp", mode = "v" },
       { "Dj", "<Plug>SchleppDupDown", mode = "v" },
       { "Dh", "<Plug>SchleppDupLeft", mode = "v" },

--- a/nvim/lua/plugins/lint.lua
+++ b/nvim/lua/plugins/lint.lua
@@ -5,10 +5,11 @@ return {
     config = function()
       local lint = require("lint")
       lint.linters_by_ft = {
+        bash = { "shellcheck" },
         go = { "golangcilint" },
         markdown = { "proselint" },
         sh = { "shellcheck" },
-        bash = { "shellcheck" },
+        yaml = { "yamllint" },
       }
     end,
   },

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -47,7 +47,6 @@ return {
           map("n", "<leader>ca", vim.lsp.buf.code_action, "Code action")
           map("n", "<leader>rn", vim.lsp.buf.rename, "Rename")
           map("n", "<leader>e", vim.diagnostic.open_float, "Diagnostics float")
-          map("n", "cmt", "<cmd>Telescope lsp_document_symbols<cr>", "Document symbols")
         end,
       })
 

--- a/nvim/lua/plugins/treesitter.lua
+++ b/nvim/lua/plugins/treesitter.lua
@@ -10,7 +10,7 @@ return {
           "go", "gomod", "gosum", "hcl", "html",
           "javascript", "json", "jsonnet", "lua", "make",
           "markdown", "markdown_inline", "nix", "proto", "python",
-          "ruby", "rust", "terraform", "toml", "tsx",
+          "rust", "terraform", "toml", "tsx",
           "typescript", "vim", "vimdoc", "yaml",
         },
       })


### PR DESCRIPTION
- Fix dunst offset deprecated syntax (30x20 -> tuple)
- Disable luarocks in lazy.nvim (no plugins need it)
- Remove redundant sysstat package (service already enabled)
- Fix README gitconfig-user variable name (USER -> GIT_USER)
- Remove dead perl/php/ruby filetype runners
- Remove ruby from treesitter ensure_installed
- Add yamllint to nvim-lint config
- Sort nvim-lint entries alphabetically