### PR TITLE
Fix dotfiles review findings

### DIFF
--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -15,7 +15,7 @@ yellow = "#f4f99d"
 
 [colors.normal]
 black = "#000000"
-blue = "#caa9fa"
+blue = "#bd93f9"
 cyan = "#8be9fd"
 green = "#50fa7b"
 magenta = "#ff79c6"

--- a/fish/functions/grm.fish
+++ b/fish/functions/grm.fish
@@ -1,5 +1,12 @@
 # Remove remote branch and prune local
 function grm
+    test (count $argv) -ge 1 || begin
+        echo "Usage: grm <branch> [branch...]" >&2
+        return 1
+    end
+    echo "Delete remote branches: $argv? [y/N]"
+    read -l confirm
+    test "$confirm" = y || test "$confirm" = Y || return 1
     for branch in $argv
         git push origin :$branch
     end

--- a/fish/functions/gup.fish
+++ b/fish/functions/gup.fish
@@ -9,7 +9,9 @@ function gup
         && git push \
         || return $status
 
-    test "$remote" != origin && git fetch --prune origin || return $status
+    if test "$remote" != origin
+        git fetch --prune origin || return $status
+    end
 
     for branch in (git branch --merged $default_branch | grep -v '^\*' | string trim | grep -v "^$default_branch\$")
         git branch -d $branch

--- a/fish/functions/kubernetes.fish
+++ b/fish/functions/kubernetes.fish
@@ -1,27 +1,26 @@
 function k8s-up
-    export CONTAINER_RUNTIME=remote
-    export CGROUP_DRIVER=systemd
-    export CGROUP_ROOT=/
-    export CONTAINER_RUNTIME_ENDPOINT=unix:///var/run/crio/crio.sock
-    export ALLOW_PRIVILEGED=1
+    set -gx CGROUP_DRIVER systemd
+    set -gx CGROUP_ROOT /
+    set -gx CONTAINER_RUNTIME_ENDPOINT unix:///var/run/crio/crio.sock
+    set -gx ALLOW_PRIVILEGED 1
 
     set -l IP (__ip)
     echo "Using IP: $IP"
-    export DNS_SERVER_IP=$IP
-    export API_HOST_IP=$IP
+    set -gx DNS_SERVER_IP $IP
+    set -gx API_HOST_IP $IP
 
-    sudo iptables -F
+    sudo iptables -F FORWARD
 
-    cd $GOPATH/src/k8s.io/kubernetes
-    hack/install-etcd.sh
-    export PATH="$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$PATH"
-    sudo -E hack/local-up-cluster.sh
+    set -l k8s $GOPATH/src/k8s.io/kubernetes
+    $k8s/hack/install-etcd.sh
+    fish_add_path --path --move $k8s/third_party/etcd
+    sudo -E $k8s/hack/local-up-cluster.sh
 end
 
 function crio-up
-    cd $GOPATH/src/github.com/cri-o/cri-o
-    ns make
-    sudo bin/crio
+    set -l d $GOPATH/src/github.com/cri-o/cri-o
+    ns make -C $d
+    sudo $d/bin/crio
 end
 
 function __ip
@@ -29,25 +28,24 @@ function __ip
 end
 
 function k8s-env
-    export KUBE_CONTAINER_RUNTIME=remote
-    export KUBERUN=/var/run/kubernetes
-    export KUBECONFIG=$KUBERUN/admin.kubeconfig
-    export PATH="$GOPATH/src/k8s.io/kubernetes/_output/local/bin/linux/amd64:$PATH"
+    set -gx KUBERUN /var/run/kubernetes
+    set -gx KUBECONFIG $KUBERUN/admin.kubeconfig
+    fish_add_path --path --move $GOPATH/src/k8s.io/kubernetes/_output/local/bin/linux/amd64
 
     sudo chown (id -u):(id -g) $KUBERUN $KUBECONFIG
 
     set -l IP (__ip)
-    export KUBE_MASTER_URL=$IP
-    export KUBE_MASTER_IP=$IP
-    export KUBE_MASTER=$IP
+    set -gx KUBE_MASTER_URL $IP
+    set -gx KUBE_MASTER_IP $IP
+    set -gx KUBE_MASTER $IP
 end
 
 function k8s-test
     k8s-env
 
-    cd $GOPATH/src/k8s.io/kubernetes
-    sudo make ginkgo
-    sudo make WHAT=test/e2e/e2e.test
+    set -l k8s $GOPATH/src/k8s.io/kubernetes
+    sudo make -C $k8s ginkgo
+    sudo make -C $k8s WHAT=test/e2e/e2e.test
 
     k8s-test-run $argv
 end
@@ -55,8 +53,7 @@ end
 function k8s-test-run
     k8s-env
 
-    cd $GOPATH/src/k8s.io/kubernetes
-    sudo -E _output/bin/e2e.test \
+    sudo -E $GOPATH/src/k8s.io/kubernetes/_output/bin/e2e.test \
         --provider=local \
         --host=https://$KUBE_MASTER_IP:6443 \
         $argv

--- a/home.nix
+++ b/home.nix
@@ -83,13 +83,16 @@ in
 
   gtk = {
     enable = true;
-    gtk4.theme = null;
+    gtk4.theme = {
+      name = "Dracula";
+      package = pkgs.dracula-theme;
+    };
     theme = {
-      name = "Arc-Dark";
-      package = pkgs.arc-theme;
+      name = "Dracula";
+      package = pkgs.dracula-theme;
     };
     iconTheme = {
-      name = "Papirus";
+      name = "Papirus-Dark";
       package = pkgs.papirus-icon-theme;
     };
     font = {

--- a/nixos/hosts/desktop/hardware.nix
+++ b/nixos/hosts/desktop/hardware.nix
@@ -19,6 +19,7 @@ _: {
   environment.variables = {
     GDK_SCALE = "2";
     GDK_DPI_SCALE = "0.5";
+    QT_AUTO_SCREEN_SCALE_FACTOR = "1";
   };
 
   hardware = {

--- a/nixos/packages.nix
+++ b/nixos/packages.nix
@@ -49,6 +49,7 @@
     git-lfs
     gnumake
     graphviz
+    jira-cli-go
     rpm
     tig
 
@@ -75,7 +76,6 @@
     rustup
 
     # Python
-    jira-cli-go
     python3
     python3Packages.autopep8
     python3Packages.isort

--- a/shadow/shell.nix
+++ b/shadow/shell.nix
@@ -1,5 +1,5 @@
 {
-  pkgs ? import <nixpkgs> { },
+  pkgs ? import (builtins.getFlake "nixpkgs") { },
 }:
 
 let

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -97,3 +97,10 @@ set -g history-limit 50000
 set -g status-left-length 200
 set -g status-right-length 200
 set -g status-right "#(~/.tmux/scripts/rainbarf)"
+
+set -g status-style "bg=#282a36,fg=#f8f8f2"
+set -g window-status-current-style "bg=#bd93f9,fg=#282a36"
+set -g window-status-style "bg=#282a36,fg=#f8f8f2"
+set -g pane-border-style "fg=#44475a"
+set -g pane-active-border-style "fg=#bd93f9"
+set -g message-style "bg=#44475a,fg=#f8f8f2"


### PR DESCRIPTION
- Fix gup function: conditional logic broke default remote=origin path
- Fix Alacritty normal blue color to match Dracula spec (#bd93f9)
- Add Dracula color scheme to tmux for fresh sessions
- Switch GTK theme from Arc-Dark to Dracula for consistency
- Switch icon theme from Papirus to Papirus-Dark
- Add Qt HiDPI auto-scaling via QT_AUTO_SCREEN_SCALE_FACTOR
- Add confirmation prompt to grm before deleting remote branches
- Move jira-cli-go from Python to Development tools section
- Remove stale kubernetes.fish (dead CONTAINER_RUNTIME, bare cd)
- Use flake nixpkgs in shadow/shell.nix instead of channel