### PR TITLE
Clean up redundant defaults, fix theming and mdc validation

### DIFF
--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -64,7 +64,7 @@ save_to_clipboard = true
 semantic_escape_chars = ",│`|:\"' ()[]{}<>"
 
 [window]
-decorations = "full"
+decorations = "none"
 dynamic_padding = false
 opacity = 1
 

--- a/fish/functions/mdc.fish
+++ b/fish/functions/mdc.fish
@@ -1,4 +1,8 @@
 # Make directory and cd into it
 function mdc
-    mkdir -p $argv[1] && cd $argv[1]
+    test (count $argv) -eq 1 || begin
+        echo "Usage: mdc <directory>" >&2
+        return 1
+    end
+    mkdir -p "$argv[1]" && cd "$argv[1]"
 end

--- a/home.nix
+++ b/home.nix
@@ -96,7 +96,7 @@ in
       package = pkgs.papirus-icon-theme;
     };
     font = {
-      name = "Sans";
+      name = "Roboto";
       size = 10;
     };
   };

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -20,7 +20,6 @@
         "nix-command"
         "flakes"
       ];
-      max-jobs = "auto";
       trusted-users = [
         "root"
         "sascha"

--- a/nixos/services.nix
+++ b/nixos/services.nix
@@ -65,7 +65,6 @@
 
     openssh = {
       enable = true;
-      ports = [ 22 ];
       settings = {
         PermitRootLogin = "no";
         PasswordAuthentication = false;

--- a/nixos/virtualisation.nix
+++ b/nixos/virtualisation.nix
@@ -5,7 +5,7 @@ _: {
       ociSeccompBpfHook.enable = true;
     };
     cri-o.enable = true;
-    docker.enable = false;
+
     libvirtd.enable = true;
     podman.enable = true;
   };

--- a/x11/profile
+++ b/x11/profile
@@ -1,2 +1,2 @@
 #!/bin/sh
-export QT_QPA_PLATFORMTHEME=gtk2
+export QT_QPA_PLATFORMTHEME=gtk3


### PR DESCRIPTION
- Remove redundant Nix defaults (`docker.enable=false`, openssh `ports=[22]`, `max-jobs="auto"`)
- Set Alacritty decorations to `"none"` (i3 strips them anyway)
- Add argument validation to `mdc` fish function
- Switch Qt platform theme from `gtk2` to `gtk3` to match Dracula GTK3/4 config
- Use `Roboto` as GTK font to match system font configuration in `fonts.nix`